### PR TITLE
Add support for multiple systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "lastModified": 1673693480,
+        "narHash": "sha256-ZM2jzyKEilkZql7ztCyvGZnoLUKdXipRhCIns98Jbqg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "rev": "cb5e28c2108ff6979e800062c67b4fe298889d3e",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.11",
+        "ref": "release-22.11",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,42 +2,66 @@
   description = "Patched turbo binary";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "nixpkgs/release-22.11";
 
   outputs = { self, nixpkgs }:
     let
-      pname = "turbo-linux-64";
-      version = "1.7.0";
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-    in
-    {
-      packages.${system} = {
-        ${pname} = pkgs.stdenv.mkDerivation {
-          inherit pname;
-          version = "v${version}";
-          src = pkgs.fetchurl {
-            url = "https://registry.npmjs.org/${pname}/-/${pname}-${version}.tgz";
-            sha256 = "sha256-CxurKoMmMCJMN9esYCN3HIl38/n0mqWtrmKo9UJSRqQ=";
-          };
-
-          nativeBuildInputs = [
-            pkgs.autoPatchelfHook
-          ];
-
-          sourceRoot = ".";
-
-          installPhase = ''
-            install -m755 -D ${pname}/bin/turbo $out/bin/turbo
-          '';
-
-          meta = {
-            homepage = "https://turbo.build/";
-            description = "Binary version of turbo, patched for NixOS";
-          };
+      binaries = {
+        "x86_64-linux" = {
+          pname = "turbo-linux-64";
+          sha256 = "1926a91gba32msnsb6plz7rpg28wfwin1b6p6x624c16hcman6qb";
         };
-
-        default = self.packages.${system}.${pname};
+        "x86_64-darwin" = {
+          pname = "turbo-darwin-64";
+          sha256 = "08y3lg439yxaljwkqyjqk3wxlv0ab3v7jyq26sdqn0ahciqqf3d5";
+        };
+        "aarch64-linux" = {
+          pname = "turbo-linux-arm64";
+          sha256 = "1lw2s7jb72pvr7vqjm8g75hq6m97slrrzwdw5lln5k67ms6nj3b6";
+        };
+        "aarch64-darwin" = {
+          pname = "turbo-darwin-arm64";
+          sha256 = "018gh9ps2x1fkck9n78l3d8ax1j5glayddl5cs56r94nj6zj1dff";
+        };
       };
+      version = "1.7.0";
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    rec {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          pname = binaries.${system}.pname;
+          sha256 = binaries.${system}.sha256;
+          inherit (pkgs.lib) optionals;
+        in {
+            default = pkgs.stdenv.mkDerivation {
+              version = "v${version}";
+              inherit pname;
+              src = pkgs.fetchurl {
+                url = "https://registry.npmjs.org/${pname}/-/${pname}-${version}.tgz";
+                inherit sha256;
+              };
+
+              nativeBuildInputs = [] ++ optionals pkgs.stdenv.isLinux [
+                pkgs.autoPatchelfHook
+              ];
+
+              sourceRoot = ".";
+
+              installPhase = ''
+                install -m755 -D ${pname}/bin/turbo $out/bin/turbo
+                install -m755 -D ${pname}/bin/go-turbo $out/bin/go-turbo
+              '';
+
+              meta = {
+                homepage = "https://turbo.build/";
+                description = "Binary version of turbo, patched for NixOS";
+              };
+            };
+          });
     };
 }


### PR DESCRIPTION
Thanks for this flake, it's really helped me out.

This PR adds support for `linux-aarch64`, `darwin-x86_64`, and `darwin-aarch64`.

It also adds `go-turbo` to the installation, since it's needed by 1.7.0 to do the things the new Rust CLI isn't able to do yet. I ran into this running a `turbo prune` command.